### PR TITLE
Add support for development and production flavors in DocDoc app

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "DocDoc Development",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main_development.dart",
+      "args": [
+        "--flavor",
+        "Development",
+        "--target",
+        "lib/main_development.dart"
+      ]
+    },
+    {
+      "name": "DocDoc Production",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main_production.dart",
+      "args": ["--flavor", "Production", "--target", "lib/main_production.dart"]
+    }
+  ]
+}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,6 +44,21 @@ android {
         versionName = flutterVersionName
     }
 
+
+    flavorDimensions "default"
+    productFlavors {
+      production {
+          dimension "default"
+          resValue "string", "app_name", "DocDoc Production"
+      }
+      development {
+          dimension "default"
+          applicationIdSuffix ".dev"
+          resValue "string", "app_name", "DocDoc Development"
+      }
+  }
+
+
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="doc_doc"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/lib/main_development.dart
+++ b/lib/main_development.dart
@@ -2,9 +2,12 @@ import 'package:doc_doc/core/di/dependency_injection.dart';
 import 'package:doc_doc/core/routing/app_router.dart';
 import 'package:doc_doc/doc_app.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-void main() {
+void main() async {
   setupGetIt();
+  // To fix texts being hidden bug in flutter_screenutil in release mode.
+  await ScreenUtil.ensureScreenSize();
   runApp(DocApp(
     appRouter: AppRouter(),
   ));

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -1,0 +1,14 @@
+import 'package:doc_doc/core/di/dependency_injection.dart';
+import 'package:doc_doc/core/routing/app_router.dart';
+import 'package:doc_doc/doc_app.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+void main() async {
+  setupGetIt();
+  // To fix texts being hidden bug in flutter_screenutil in release mode.
+  await ScreenUtil.ensureScreenSize();
+  runApp(DocApp(
+    appRouter: AppRouter(),
+  ));
+}


### PR DESCRIPTION
This commit introduces the setup for differentiating between development and production environments in the DocDoc application. It includes the creation of separate entry points for each flavor (`lib/main_development.dart` and `lib/main_production.dart`), configuration of flavor-specific settings in `android/app/build.gradle`, and adjustments to the AndroidManifest.xml to use dynamic app names based on the flavor. Additionally, a new launch.json file in the .vscode directory is added to support debugging with the specified flavors.

The changes enable the app to run in two distinct modes, each with its own configuration and entry point, facilitating easier development and testing while maintaining separate production settings.